### PR TITLE
Fix Q4_01 solution to handle the start node case

### DIFF
--- a/Java/Ch 04. Trees and Graphs/Q4_01_Route_Between_Nodes/Question.java
+++ b/Java/Ch 04. Trees and Graphs/Q4_01_Route_Between_Nodes/Question.java
@@ -39,7 +39,10 @@ public class Question {
 		return g;
 	}
 
-    public static boolean search(Graph g,Node start,Node end) {  
+    public static boolean search(Graph g,Node start,Node end) {
+    	 if (start == end ) {
+            return true;
+        }
         LinkedList<Node> q = new LinkedList<Node>();
         for (Node u : g.getNodes()) {
             u.state = State.Unvisited;


### PR DESCRIPTION
In the current implementation prior the PR, the start node is never compared to the end, which means if the passed parameter start == end, it would return false.