### PR TITLE
Resolved incorrect function name in preorder and post order recursive…

### DIFF
--- a/Java/Ch 04. Trees and Graphs/Introduction/Traversals.java
+++ b/Java/Ch 04. Trees and Graphs/Introduction/Traversals.java
@@ -20,15 +20,15 @@ public class Traversals {
 	public static void preOrderTraversal(TreeNode node) {
 		if (node != null) {
 			visit(node);
-			inOrderTraversal(node.left);
-			inOrderTraversal(node.right);
+			preOrderTraversal(node.left);
+			preOrderTraversal(node.right);
 		}
 	}
 	
 	public static void postOrderTraversal(TreeNode node) {
 		if (node != null) {
-			inOrderTraversal(node.left);
-			inOrderTraversal(node.right);
+		    postOrderTraversal(node.left);
+		    postOrderTraversal(node.right);
 			visit(node);
 		}
 	}	


### PR DESCRIPTION
The recursive function preorder and postorder traversal is calling to inorder traversal function, which is wrong and created pull request to resolve this bug.  

I found this issue in the 6th Ed book.

Java/Ch 04. Trees and Graphs/Introduction/Traversals.java