### PR TITLE
17.18 New solution in O(S + B) time

### DIFF
--- a/Java/Ch 17. Hard/Q17_18_Shortest_Supersequence/QuestionE.java
+++ b/Java/Ch 17. Hard/Q17_18_Shortest_Supersequence/QuestionE.java
@@ -1,0 +1,48 @@
+package Q17_18_Shortest_Supersequence;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class QuestionE {
+
+    public static Range shortestSupersequence(int[] big, int[] small) {
+        Range range = null;
+        /* Convert the small array to a Set. */
+        final Set<Integer> smallSet = Arrays.stream(small).boxed().collect(Collectors.toSet());
+        /* This Map stores the numbers from smallSet found in the big array
+         * in order of appearance, alongside their most recent index. */
+        final Map<Integer, Integer> numAtIdx = new LinkedHashMap<>();
+
+        /* Walk through the big array, adding matching numbers and indices to the Map.
+         * Elements already present in the Map are removed first to maintain insertion order. */
+        for (int idx = 0; idx < big.length; idx++) {
+            if (smallSet.contains(big[idx])) {
+                numAtIdx.remove(big[idx]);
+                numAtIdx.put(big[idx], idx);
+
+                if (numAtIdx.size() == smallSet.size()) {
+                    /* If we found all numbers, calculate the length of the range. */
+                    final int start = numAtIdx.values().iterator().next();
+                    final int candidateLength = idx - start + 1;
+
+                    /* Instate the range if it's the first one found or in case it's shorter. */
+                    if (range == null || range.length() > candidateLength) {
+                        range = new Range(start, idx);
+
+                        /* Stop early if the elements are adjacent. We can't do any better. */
+                        if (range.length() == smallSet.size()) break;
+                    }
+
+                    /* Remove the range's leftmost element. */
+                    numAtIdx.remove(big[start]);
+                }
+            }
+        }
+
+        return range;
+    }
+
+}

--- a/Java/Ch 17. Hard/Q17_18_Shortest_Supersequence/Tester.java
+++ b/Java/Ch 17. Hard/Q17_18_Shortest_Supersequence/Tester.java
@@ -13,11 +13,13 @@ public class Tester {
 		Range shortestB = QuestionB.shortestSupersequence(array, set);
 		Range shortestC = QuestionC.shortestSupersequence(array, set);
 		Range shortestD = QuestionD.shortestSupersequence(array, set);
-		
+		Range shortestE = QuestionE.shortestSupersequence(array, set);
+
 		
 		if (shortestA.length() != shortestB.length() || 
 			shortestB.length() != shortestC.length() || 
-			shortestC.length() != shortestD.length()) {
+			shortestC.length() != shortestD.length() ||
+			shortestD.length() != shortestE.length()) {
 			System.out.println("Mismatching.");
 		} else {
 			System.out.println("Matching: " + shortestA.length());


### PR DESCRIPTION
This implementation uses a LinkedHashMap to keep track of the matching numbers (key) and indices (value) found whilst iterating through the big array. If a number is encountered again, we remove it from the Map first, thus maintaining insertion order. Doing so provides us with a "sliding window" of each number's most recent occurrence in order of appearance.

Once we've found all the numbers (i.e. the Map's size equals the small array's length), we calculate the prospective range's length and update the result if necessary. At this juncture, the Map's first item holds the range's start index, while the loop counter (idx) serves as the end index. As an optimisation, we stop early in case we've found the shortest possible window, i.e. the elements are adjacent in the big array. Finally, we shorten the window by removing the first (leftmost) item from the Map and carry on with the loop.

The time complexity is O(S + B) - the time it takes to create the Set from the small array and iterate through the big array.
The space complexity is O(S) - the (maximum) size of both, the Set and Map.