### PR TITLE
 Question 2.6: no need to calculate length in the recursive solution

### DIFF
--- a/Java/Ch 02. Linked Lists/Q2_06_Palindrome/QuestionC.java
+++ b/Java/Ch 02. Linked Lists/Q2_06_Palindrome/QuestionC.java
@@ -12,15 +12,15 @@ public class QuestionC {
 		}
 	}
 
-	public static Result isPalindromeRecurse(LinkedListNode head, int length) {
-		if (head == null || length <= 0) { // Even number of nodes
-			return new Result(head, true);
-		} else if (length == 1) { // Odd number of nodes
-			return new Result(head.next, true);
+	public static Result isPalindromeRecurse(LinkedListNode slow, LinkedListNode fast) {
+		if (fast.next == null) { // Odd number of nodes: we are at the mid element
+			return new Result(slow.next, true);
+		} else if (fast.next.next == null) { // Even number of nodes: the two mids need comparison
+			return new Result(slow.next.next, slow.data == slow.next.data);
 		} 
 		
 		/* Recurse on sublist. */
-		Result res = isPalindromeRecurse(head.next, length - 2);
+		Result res = isPalindromeRecurse(slow.next, fast.next.next);
 		
 		/* If child calls are not a palindrome, pass back up 
 		 * a failure. */
@@ -29,7 +29,7 @@ public class QuestionC {
 		} 
 		
 		/* Check if matches corresponding node on other side. */
-		res.result = (head.data == res.node.data); 
+		res.result = (slow.data == res.node.data);
 		
 		/* Return corresponding node. */
 		res.node = res.node.next;
@@ -37,18 +37,11 @@ public class QuestionC {
 		return res;
 	}
 	
-	public static int lengthOfList(LinkedListNode n) {
-		int size = 0;
-		while (n != null) {
-			size++;
-			n = n.next;
-		}
-		return size;
-	}
-	
 	public static boolean isPalindrome(LinkedListNode head) {
-		int length = lengthOfList(head);
-		Result p = isPalindromeRecurse(head, length);
+		if (head == null) {
+			return true;
+		}
+		Result p = isPalindromeRecurse(head, head);
 		return p.result;
 	}
 	

--- a/Java/Ch 02. Linked Lists/Q2_06_Palindrome/QuestionC.java
+++ b/Java/Ch 02. Linked Lists/Q2_06_Palindrome/QuestionC.java
@@ -13,7 +13,7 @@ public class QuestionC {
 	}
 
 	public static Result isPalindromeRecurse(LinkedListNode slow, LinkedListNode fast) {
-		if (fast.next == null) { // Odd number of nodes: we are at the mid element
+		if (fast.next == null) { // Odd number of nodes: slow is at the mid element
 			return new Result(slow.next, true);
 		} else if (fast.next.next == null) { // Even number of nodes: the two mids need comparison
 			return new Result(slow.next.next, slow.data == slow.next.data);


### PR DESCRIPTION
By using the runner technique it seem possible to avoid having to calculate the length of the list in the recursive solution, allowing to iterate the whole list one time less (not a difference in Big-O perspective, but still slightly more performant).